### PR TITLE
Update template to utilize salt-master locally along with gitfs based salt-formulas

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.ssh.forward_agent = true
 
-  config.vm.synced_folder ".", "/project"
+  config.vm.synced_folder ".", "/home/vagrant/domains/{{ name }}",
+    owner: "vagrant",
+    group: "vagrant",
+    mount_options: ["dmode=755,fmode=644"]
 
   # provision our box with salt but do not run the highstate yet
   # we still need to setup our stackstrap repository after salt is installed

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,19 +4,6 @@
 VAGRANTFILE_API_VERSION = "2"
 CURRENT_USER = `whoami`.chomp
 
-# our script to install the stackstrap states on the vagrant box
-$stackstrap_salt_script = <<SCRIPT
-# install git
-salt-call pkg.install git
-
-# setup our /srv directory
-# TODO: make the GIT URL & ref configurable
-cd /tmp
-git clone https://github.com/freesurface/stackstrap-salt.git stackstrap-salt
-cd stackstrap-salt
-git archive master --prefix=/srv/ | (cd /; tar xf -)
-SCRIPT
-
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = "{{ name }}-#{CURRENT_USER}"
 
@@ -33,14 +20,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # we still need to setup our stackstrap repository after salt is installed
   config.vm.provision :salt do |salt|
     salt.minion_config = "salt/minion"
-    salt.run_highstate = false
+    salt.master_config = "salt/master"
+    salt.install_master = true
+    salt.run_highstate = true
   end
-
-  # get our stackstrap salt repository setup
-  config.vm.provision :shell, inline: $stackstrap_salt_script
-
-  # now run the highstate
-  config.vm.provision :shell, inline: "salt-call state.highstate"
 
   config.vm.provision :shell,
     inline: "echo; echo; echo \"Your development environment is now configured\"; echo \"You can access it at http://{{ name }}-#{CURRENT_USER}.local/\"; echo"

--- a/salt/master
+++ b/salt/master
@@ -1,0 +1,30 @@
+#
+# StackStrap salt master config
+#
+
+# listed on the loopback in open mode
+# this is so that our client does not need to have its key accepted
+# greatly simplifying the provisioning process
+interface: 127.0.0.1
+open_mode: True
+
+# use both the local roots as well as gitfs remotes
+fileserver_backend:
+  - roots
+  - git
+
+# map our project specific files to the local roots
+file_roots:
+  base:
+    - /project/salt/root
+pillar_roots:
+  base:
+    - /project/salt/pillar
+
+{% if 'salt_formulas' in template.meta -%}
+# setup our salt formulas as gitfs remotes
+gitfs_remotes:
+{% for formula in template.meta['salt_formulas'] -%}
+  - {{ formula }}
+{%- endfor %}
+{%- endif %}

--- a/salt/master
+++ b/salt/master
@@ -16,10 +16,10 @@ fileserver_backend:
 # map our project specific files to the local roots
 file_roots:
   base:
-    - /project/salt/root
+    - /vagrant/salt/root
 pillar_roots:
   base:
-    - /project/salt/pillar
+    - /vagrant/salt/pillar
 
 {% if 'salt_formulas' in template.meta -%}
 # setup our salt formulas as gitfs remotes

--- a/salt/minion
+++ b/salt/minion
@@ -1,10 +1,9 @@
+#
+# StackStrap salt minion config
+#
+
+# connect to our local master
+master: 127.0.0.1
+
+# only report changed state items
 state_verbose: False
-file_client: local
-file_roots:
-  base:
-    - /project/salt/root
-    - /srv/salt
-pillar_roots:
-  base:
-    - /project/salt/pillar
-    - /srv/pillar

--- a/stackstrap-template.yml
+++ b/stackstrap-template.yml
@@ -12,6 +12,10 @@ cleanup:
 
 file_templates:
   - Vagrantfile
+  - salt/master
 
 path_templates:
   - PROJECT-README: README
+
+salt_formulas:
+  - https://github.com/saltstack-formulas/avahi-formula.git


### PR DESCRIPTION
As discussed this is a pull request that sets up the master template to deploy & configure a local salt-master on the Vagrant instance that is setup to utilize the salt formulas:
- https://github.com/saltstack-formulas
- http://docs.saltstack.com/topics/conventions/formulas.html

No changes were required to stackstrap since the `template` object is already available in the context it means that I can grab what I need directly from it. (I will start a new branch on stackstrap to implement the extra context data feature we discussed, but it's now 100% separate from this one).
